### PR TITLE
Fix bug: ratio index out of range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,4 @@ __*/
 *.ckpt
 *.pth
 *.safetensors
+HunyuanImage-3/

--- a/PE/deepseek.py
+++ b/PE/deepseek.py
@@ -24,7 +24,7 @@ class DeepSeekClient(object):
         cred = credential.Credential(key_id, key_secret)
         httpProfile = HttpProfile()
         httpProfile.endpoint = "lkeap.tencentcloudapi.com"
-        httpProfile.reqTimeout = 40000  # 流式接口可能耗时较长
+        httpProfile.reqTimeout = 40000  # The streaming interface may take a longer time.
         clientProfile = ClientProfile()
         clientProfile.httpProfile = httpProfile
         self.common_client = CommonClient("lkeap", "2024-05-22", cred, "ap-guangzhou", profile=clientProfile)

--- a/hunyuan_image_3/hunyuan.py
+++ b/hunyuan_image_3/hunyuan.py
@@ -2643,6 +2643,10 @@ class HunyuanImage3ForCausalMM(HunyuanImage3PreTrainedModel, GenerationMixin):
                 prompt=prompt, cot_text=cot_text, bot_task="img_ratio", system_prompt=system_prompt, seed=seed)
             outputs = self._generate(**model_inputs, **kwargs, verbose=verbose)
             ratio_index = outputs[0, -1].item() - self._tkwrapper.ratio_token_offset
+            # In some cases, the generated ratio_index is out of range. A valid ratio_index should be in [0, 32].
+            # If ratio_index is out of range, we set it to 16 (i.e., 1:1).
+            if ratio_index < 0 or ratio_index >= len(self.image_processor.reso_group):
+                ratio_index = 16
             reso = self.image_processor.reso_group[ratio_index]
             image_size = reso.height, reso.width
 

--- a/run_image_gen.py
+++ b/run_image_gen.py
@@ -96,8 +96,9 @@ def main(args):
     model = HunyuanImage3ForCausalMM.from_pretrained(args.model_id, **kwargs)
     model.load_tokenizer(args.model_id)
 
+    # Rewrite prompt with DeepSeek
     if args.rewrite:
-        # 通过环境变量获取DeepSeek的key_id和key_secret
+        # Get request key_id and key_secret for DeepSeek
         deepseek_key_id = os.getenv("DEEPSEEK_KEY_ID")
         deepseek_key_secret = os.getenv("DEEPSEEK_KEY_SECRET")
         if not deepseek_key_id or not deepseek_key_secret:


### PR DESCRIPTION
This PR is for solving the bug entioned in the #11 . This bug is casued by the failed prediction of <img_ratio_*> tokens in the `auto` mode of image resolution.

We can solve the problem by set a default value `16` (i.e., `1024x1024` for image_size) for wrong shape prediction.