### PR TITLE
Optimize MoE forward pass for single token generation in eager mode

### DIFF
--- a/hunyuan_image_3/modeling_hunyuan_image_3.py
+++ b/hunyuan_image_3/modeling_hunyuan_image_3.py
@@ -1199,30 +1199,34 @@ class HunyuanMoE(nn.Module):
                 )
                 combined_output = combined_output.reshape(bsz, seq_len, hidden_size)
             else:
-                # DeepSeekMoE implementation
-                # Reference: https://huggingface.co/deepseek-ai/deepseek-moe-16b-chat/blob/main/modeling_deepseek.py#L375
-                with torch.autocast('cuda', enabled=False):
-                    topk_weights, topk_idx = self.gate(hidden_states, topk_impl='easy')
-                # Cast back to the input dtype
-                topk_weights = topk_weights.to(hidden_states.dtype)
+                if bsz == 1 and seq_len == 1:
+                    combined_output = self.forward_single_token(hidden_states, hidden_size)
+                else:
+                    # DeepSeekMoE implementation
+                    # Reference: https://huggingface.co/deepseek-ai/deepseek-moe-16b-chat/blob/main/modeling_deepseek.py#L375
+                    with torch.autocast('cuda', enabled=False):
+                        topk_weights, topk_idx = self.gate(hidden_states, topk_impl='easy')
+                    # Cast back to the input dtype
+                    topk_weights = topk_weights.to(hidden_states.dtype)
 
-                # Flatten for easier indexing
-                flat_topk_idx = topk_idx.view(-1)
-                hidden_states_flat = input_hidden_states.view(-1, hidden_size)    # (bsz * seq_len, hidden_size)
-                hidden_states_repeated = hidden_states_flat.repeat_interleave(self.moe_topk, dim=0)  # (bsz * seq_len * k, hidden_size)
+                    # Flatten for easier indexing
+                    flat_topk_idx = topk_idx.view(-1)
+                    hidden_states_flat = input_hidden_states.view(-1, hidden_size)    # (bsz * seq_len, hidden_size)
+                    hidden_states_repeated = hidden_states_flat.repeat_interleave(self.moe_topk, dim=0)  # (bsz * seq_len * k, hidden_size)
 
-                # Forward through experts
-                expert_outputs = torch.zeros_like(hidden_states_repeated, dtype=hidden_states_repeated.dtype, device=hidden_states_repeated.device)
-                for i in range(self.num_experts):
-                    expert_mask = (flat_topk_idx == i)
-                    selected_inputs = hidden_states_repeated[expert_mask]
-                    expert_output = self.experts[i](selected_inputs)    # compatible with zero tensor
-                    expert_outputs[expert_mask] = expert_output
+                    # Forward through experts
+                    expert_outputs = torch.zeros_like(hidden_states_repeated, dtype=hidden_states_repeated.dtype, device=hidden_states_repeated.device)
+                    for i in range(self.num_experts):
+                        expert_mask = (flat_topk_idx == i)
+                        selected_inputs = hidden_states_repeated[expert_mask]
+                        expert_output = self.experts[i](selected_inputs)    # compatible with zero tensor
+                        expert_outputs[expert_mask] = expert_output
 
-                # Weighted sum of expert outputs
-                combined_output = (expert_outputs.view(
-                    bsz * seq_len, self.moe_topk, hidden_size) * topk_weights.unsqueeze(-1)).sum(dim=1)  # (bsz * seq_len, hidden_size)
-                combined_output = combined_output.to(hidden_states.dtype).view(bsz, seq_len, hidden_size)
+                    # Weighted sum of expert outputs
+                    combined_output = (expert_outputs.view(
+                        bsz * seq_len, self.moe_topk, hidden_size) * topk_weights.unsqueeze(-1)).sum(dim=1)  # (bsz * seq_len, hidden_size)
+                    combined_output = combined_output.to(hidden_states.dtype)
+                combined_output = combined_output.reshape(bsz, seq_len, hidden_size)
 
         if self.config.use_mixed_mlp_moe:
             output = hidden_states_mlp + combined_output    # noqa
@@ -1230,6 +1234,28 @@ class HunyuanMoE(nn.Module):
             output = combined_output
 
         return output
+
+    def forward_single_token(self, hidden_states, hidden_size):
+        assert hidden_states.numel() == hidden_size, "B*L must be 1"
+        dtype = hidden_states.dtype
+
+        gates_input = hidden_states.reshape(-1, hidden_size)
+        if self.gate.wg.weight.dtype == torch.flaot32:
+            gates_input = gates_input.float()
+        logits = self.gate.wg(gates_input)
+        gates = F.softmax(logits.float(), dim=-1)
+
+        moe_topk = self.config.moe_topk if isinstance(self.config.moe_topk, int) else self.config.moe_topk[self.layer_idx]
+        topk_prob, topk_idx = torch.topk(gates, k=moe_topk, dim=-1)
+        topk_prob = topk_prob.squeeze(0).to(dtype)
+        topk_idx = topk_idx.squeeze(0)
+
+        y = torch.zeros_like(hidden_states)
+        for p, idx in zip(topk_prob, topk_idx):
+            out_e = self.experts[idx.item()](hidden_states)
+            y += p * out_e
+
+        return y.view(1, 1, hidden_size)
 
     def _initialize_weights_on_device(self, device):
         expert_weights_gate_up = []

--- a/hunyuan_image_3/modeling_hunyuan_image_3.py
+++ b/hunyuan_image_3/modeling_hunyuan_image_3.py
@@ -1240,7 +1240,7 @@ class HunyuanMoE(nn.Module):
         dtype = hidden_states.dtype
 
         gates_input = hidden_states.reshape(-1, hidden_size)
-        if self.gate.wg.weight.dtype == torch.flaot32:
+        if self.gate.wg.weight.dtype == torch.float32:
             gates_input = gates_input.float()
         logits = self.gate.wg(gates_input)
         gates = F.softmax(logits.float(), dim=-1)


### PR DESCRIPTION
# Optimize MoE forward pass for single token generation in eager mode， faster text generation

## Description
This PR optimizes the MoE (Mixture of Experts) forward pass specifically for the single token generation scenario (batch size = 1, sequence length = 1) in eager execution mode. The current implementation uses a generic approach that involves tensor reshaping, repeating, and mask-based expert selection, which introduces unnecessary computational overhead during autoregressive generation where tokens are processed one by one. 

## Key Changes
- Added a specialized `forward_single_token` method for efficient single-token MoE computation
- Bypass complex tensor manipulations and masking operations when `bsz == 1 and seq_len == 1`
- Directly compute top-k routing probabilities and apply weighted expert outputs

## Performance Improvements
The new implementation eliminates redundant operations by:
- Avoiding tensor flattening and repeating operations
- Removing mask-based expert selection loops
- Direct matrix multiplication with selected experts

Preliminary speed measurements for text generation (NVIDAI H20:) (tokens/second):

| Configuration | Before | After | Improvement |
|--------------|--------|-------|-------------|
| Single token eager mode | `3.28 token/s` | `8.97 token/s` | `x2.73` |
