### PR TITLE
feat: add MiniMax Cloud API as alternative prompt enhancement provider

### DIFF
--- a/PE/minimax_client.py
+++ b/PE/minimax_client.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+"""
+MiniMax Client Module
+
+This module provides a client interface for interacting with MiniMax Cloud API
+for prompt enhancement (recaptioning) in HunyuanImage-3.0.
+
+MiniMax offers an OpenAI-compatible API at https://api.minimax.io/v1 with
+models like MiniMax-M2.7 and MiniMax-M2.5 that support large context windows.
+"""
+import json
+import os
+import time
+from loguru import logger
+
+try:
+    from openai import OpenAI
+except ImportError:
+    OpenAI = None
+
+
+class MiniMaxClient(object):
+    """
+    Client for interacting with MiniMax Cloud API for prompt recaptioning.
+
+    MiniMax provides an OpenAI-compatible API that can be used as an alternative
+    to DeepSeek for prompt enhancement in image generation workflows.
+
+    The client supports MiniMax-M2.7 (latest, 1M context) and MiniMax-M2.5
+    (204K context) models.
+    """
+
+    BASE_URL = "https://api.minimax.io/v1"
+    DEFAULT_MODEL = "MiniMax-M2.7"
+
+    def __init__(self, api_key=None, model=None):
+        """
+        Initialize the MiniMax client.
+
+        Args:
+            api_key (str, optional): MiniMax API key. If not provided, reads
+                from MINIMAX_API_KEY environment variable.
+            model (str, optional): Model to use. Defaults to MiniMax-M2.7.
+                Options: MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5,
+                MiniMax-M2.5-highspeed.
+
+        Raises:
+            ImportError: If the openai package is not installed.
+            ValueError: If no API key is provided or found in environment.
+        """
+        if OpenAI is None:
+            raise ImportError(
+                "The 'openai' package is required for MiniMax provider. "
+                "Install it with: pip install openai"
+            )
+
+        self.api_key = api_key or os.getenv("MINIMAX_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "MiniMax API key is required. Set the MINIMAX_API_KEY "
+                "environment variable or pass api_key to the constructor."
+            )
+
+        self.model = model or self.DEFAULT_MODEL
+        self.client = OpenAI(
+            api_key=self.api_key,
+            base_url=self.BASE_URL,
+        )
+
+    def run_single_recaption(self, system_prompt, input_prompt):
+        """
+        Run a single prompt recaptioning request.
+
+        This method sends a prompt to MiniMax API for enhancement/recaptioning,
+        matching the same interface as DeepSeekClient.run_single_recaption().
+
+        Args:
+            system_prompt (str): System prompt that defines the task and behavior.
+            input_prompt (str): User input prompt to be recaptioned/enhanced.
+
+        Returns:
+            tuple: A tuple containing:
+                - content (str): The recaptioned/enhanced prompt.
+                - reason (str): The reasoning content (empty string if the model
+                    does not return reasoning).
+
+        Note:
+            The method includes retry logic to handle transient API errors.
+            It will retry with a 1-second delay if an exception occurs.
+        """
+        print("Start to run recaption (MiniMax): ")
+
+        # MiniMax temperature must be in (0.0, 1.0]
+        temperature = 0.7
+
+        # Retry loop to handle transient API errors
+        while True:
+            try:
+                response = self.client.chat.completions.create(
+                    model=self.model,
+                    messages=[
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": input_prompt},
+                    ],
+                    temperature=temperature,
+                    stream=False,
+                )
+                break
+            except Exception as e:
+                logger.error(f"MiniMax API error: {e}")
+                time.sleep(1)
+
+        # Extract the enhanced prompt content
+        choice = response.choices[0]
+        content = choice.message.content or ""
+
+        # Strip thinking tags if present (MiniMax-M2.7 may include them)
+        content = _strip_think_tags(content)
+
+        # MiniMax does not return separate reasoning content via the
+        # standard OpenAI-compatible API, so we return an empty string
+        reason = ""
+
+        # Print debug information
+        print("Initial prompt: ", input_prompt)
+        print("Recaption prompt: ", content)
+
+        return content, reason
+
+
+def _strip_think_tags(text):
+    """
+    Remove <think>...</think> tags from model output.
+
+    Some MiniMax models may include reasoning in <think> tags. This function
+    strips those tags and returns only the final content.
+
+    Args:
+        text (str): The model output text.
+
+    Returns:
+        str: Text with think tags removed.
+    """
+    import re
+    cleaned = re.sub(r"<think>.*?</think>\s*", "", text, flags=re.DOTALL)
+    return cleaned.strip()

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ pip install torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0 --index-url https
 # 2. Install tencentcloud-sdk for Prompt Enhancement (PE) only for HunyuanImage-3.0 not HunyuanImage-3.0-Instruct
 pip install -i https://mirrors.tencent.com/pypi/simple/ --upgrade tencentcloud-sdk-python
 
+# 2b. (Optional) Install openai SDK if using MiniMax for Prompt Enhancement
+pip install openai
+
 # 3. Then install other dependencies
 pip install -r requirements.txt
 ```
@@ -332,7 +335,7 @@ hf download tencent/HunyuanImage-3.0 --local-dir ./HunyuanImage-3
 ```
 
 ##### 3️⃣ Run the Demo
-The Pretrain Checkpoint does not automatically rewrite or enhance input prompts, for optimal results currently, we recommend community partners to use deepseek to rewrite the prompts. You can go to [Tencent Cloud](https://cloud.tencent.com/document/product/1772/115963#.E5.BF.AB.E9.80.9F.E6.8E.A5.E5.85.A5) to apply for an API Key.
+The Pretrain Checkpoint does not automatically rewrite or enhance input prompts, for optimal results currently, we recommend community partners to use deepseek to rewrite the prompts. You can go to [Tencent Cloud](https://cloud.tencent.com/document/product/1772/115963#.E5.BF.AB.E9.80.9F.E6.8E.A5.E5.85.A5) to apply for an API Key. Alternatively, you can use [MiniMax](https://platform.minimaxi.com/) as the LLM provider for prompt enhancement by setting `--llm-provider minimax`.
 
 ```bash
 # Without PE
@@ -360,6 +363,20 @@ python3 run_image_gen.py \
     --moe-impl flashinfer \
     --rewrite 1
 
+# With PE (MiniMax)
+export MINIMAX_API_KEY="your_minimax_api_key"
+export MODEL_PATH="./HunyuanImage-3"
+python3 run_image_gen.py \
+    --model-id $MODEL_PATH \
+    --verbose 1 \
+    --prompt "A brown and white dog is running on the grass" \
+    --bot-task image \
+    --image-size "1024x1024" \
+    --save ./image.png \
+    --moe-impl flashinfer \
+    --rewrite 1 \
+    --llm-provider minimax
+
 ```
 
 ##### 4️⃣ Command Line Arguments
@@ -376,6 +393,8 @@ python3 run_image_gen.py \
 | `--save`                | Image save path.                                             | `image.png` |
 | `--verbose`             | Verbose level. 0: No log; 1: log inference information.      | `0`         |
 | `--rewrite`             | Whether to enable rewriting                                  | `1`         |
+| `--llm-provider`        | LLM provider for prompt rewriting. `deepseek` or `minimax`   | `deepseek`  |
+| `--sys-prompt-type`     | System prompt type. `universal` or `text_rendering`          | `universal` |
 
 #### 🎨 Interactive Gradio Demo
 

--- a/run_image_gen.py
+++ b/run_image_gen.py
@@ -16,7 +16,6 @@ import os
 from pathlib import Path
 from hunyuan_image_3 import HunyuanImage3ForCausalMM
 from PIL import Image
-from PE.deepseek import DeepSeekClient
 from PE.system_prompt import system_prompt_universal, system_prompt_text_rendering
 
 def parse_args():
@@ -73,7 +72,30 @@ def parse_args():
     )
     parser.add_argument("--save", type=str, default="image.png", help="Path to save the generated image")
     parser.add_argument("--verbose", type=int, default=2, help="Verbose level")
-    parser.add_argument("--rewrite", type=int, default=0, help="Whether to rewrite the prompt with DeepSeek")
+    parser.add_argument("--rewrite", type=int, default=0, help="Whether to rewrite the prompt with an LLM provider")
+    parser.add_argument(
+        "--llm-provider",
+        type=str,
+        default="deepseek",
+        choices=["deepseek", "minimax"],
+        help=(
+            "LLM provider for prompt rewriting (used with --rewrite 1). "
+            "'deepseek' uses Tencent Cloud LKEAP service (requires DEEPSEEK_KEY_ID "
+            "and DEEPSEEK_KEY_SECRET). 'minimax' uses MiniMax Cloud API (requires "
+            "MINIMAX_API_KEY). Default: deepseek"
+        )
+    )
+    parser.add_argument(
+        "--sys-prompt-type",
+        type=str,
+        default="universal",
+        choices=["universal", "text_rendering"],
+        help=(
+            "System prompt type for prompt rewriting. 'universal' for general "
+            "image prompt enhancement; 'text_rendering' for prompts involving "
+            "text rendering. Default: universal"
+        )
+    )
 
     parser.add_argument("--reproduce", action="store_true", help="Whether to reproduce the results")
     parser.add_argument(
@@ -180,24 +202,40 @@ def main(args):
     else:
         image_input = None
     
-    # Rewrite prompt with DeepSeek When use HunyuanImage-3.0
+    # Rewrite prompt with LLM provider when using HunyuanImage-3.0
     if args.rewrite:
-        # Get request key_id and key_secret for DeepSeek
-        deepseek_key_id = os.getenv("DEEPSEEK_KEY_ID")
-        deepseek_key_secret = os.getenv("DEEPSEEK_KEY_SECRET")
-        if not deepseek_key_id or not deepseek_key_secret:
-            raise ValueError(f"DeepSeek API key is not set!!! The Pretrain Checkpoint does not "
-                             f"automatically rewrite or enhance input prompts, for optimal results currently,"
-                             f"we recommend community partners to use deepseek to rewrite the prompts.")
-        deepseek_client = DeepSeekClient(deepseek_key_id, deepseek_key_secret)
-        
-        if args.sys_deepseek_prompt == "universal":
+        # Select system prompt
+        if args.sys_prompt_type == "universal":
             system_prompt = system_prompt_universal
-        elif args.sys_deepseek_prompt == "text_rendering":
+        elif args.sys_prompt_type == "text_rendering":
             system_prompt = system_prompt_text_rendering
         else:
-            raise ValueError(f"Invalid system prompt: {args.sys_deepseek_prompt}")
-        prompt, _ = deepseek_client.run_single_recaption(system_prompt, args.prompt)
+            raise ValueError(f"Invalid system prompt type: {args.sys_prompt_type}")
+
+        if args.llm_provider == "minimax":
+            # Use MiniMax Cloud API
+            from PE.minimax_client import MiniMaxClient
+            minimax_api_key = os.getenv("MINIMAX_API_KEY")
+            if not minimax_api_key:
+                raise ValueError(
+                    "MINIMAX_API_KEY environment variable is not set. "
+                    "Get your API key from https://platform.minimaxi.com/"
+                )
+            llm_client = MiniMaxClient(api_key=minimax_api_key)
+        else:
+            # Use DeepSeek via Tencent Cloud LKEAP (default)
+            from PE.deepseek import DeepSeekClient
+            deepseek_key_id = os.getenv("DEEPSEEK_KEY_ID")
+            deepseek_key_secret = os.getenv("DEEPSEEK_KEY_SECRET")
+            if not deepseek_key_id or not deepseek_key_secret:
+                raise ValueError(
+                    f"DeepSeek API key is not set!!! The Pretrain Checkpoint does not "
+                    f"automatically rewrite or enhance input prompts, for optimal results currently,"
+                    f"we recommend community partners to use deepseek to rewrite the prompts."
+                )
+            llm_client = DeepSeekClient(deepseek_key_id, deepseek_key_secret)
+
+        prompt, _ = llm_client.run_single_recaption(system_prompt, args.prompt)
         print("rewrite prompt: {}".format(prompt))
         args.prompt = prompt
     cot_text, samples = model.generate_image(

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -1,0 +1,455 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for MiniMax Client Module and LLM Provider Integration
+
+This module contains unit tests and integration tests for the MiniMax prompt
+enhancement client and the multi-provider support in run_image_gen.py.
+"""
+import json
+import os
+import re
+import sys
+import unittest
+from unittest.mock import MagicMock, patch, PropertyMock
+
+# Add project root to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# ---------------------------------------------------------------------------
+# Unit Tests
+# ---------------------------------------------------------------------------
+
+class TestStripThinkTags(unittest.TestCase):
+    """Test the _strip_think_tags helper function."""
+
+    def test_no_think_tags(self):
+        """Content without think tags should be returned unchanged."""
+        from PE.minimax_client import _strip_think_tags
+        text = "A beautiful sunset over the ocean."
+        self.assertEqual(_strip_think_tags(text), text)
+
+    def test_think_tags_removed(self):
+        """Think tags and their content should be stripped."""
+        from PE.minimax_client import _strip_think_tags
+        text = "<think>I should enhance this prompt...</think>A beautiful sunset over the ocean."
+        result = _strip_think_tags(text)
+        self.assertEqual(result, "A beautiful sunset over the ocean.")
+
+    def test_multiline_think_tags(self):
+        """Multiline think content should be fully stripped."""
+        from PE.minimax_client import _strip_think_tags
+        text = (
+            "<think>\nLet me analyze this prompt.\n"
+            "The user wants a landscape.\n</think>\n"
+            "A cinematic wide-angle landscape."
+        )
+        result = _strip_think_tags(text)
+        self.assertEqual(result, "A cinematic wide-angle landscape.")
+
+    def test_empty_think_tags(self):
+        """Empty think tags should be stripped."""
+        from PE.minimax_client import _strip_think_tags
+        text = "<think></think>Enhanced prompt here."
+        result = _strip_think_tags(text)
+        self.assertEqual(result, "Enhanced prompt here.")
+
+    def test_only_think_tags(self):
+        """If only think tags exist, result should be empty."""
+        from PE.minimax_client import _strip_think_tags
+        text = "<think>Only reasoning, no content.</think>"
+        result = _strip_think_tags(text)
+        self.assertEqual(result, "")
+
+    def test_whitespace_after_think_tags(self):
+        """Whitespace between think tags and content should be handled."""
+        from PE.minimax_client import _strip_think_tags
+        text = "<think>reasoning</think>   \n  Actual content."
+        result = _strip_think_tags(text)
+        self.assertEqual(result, "Actual content.")
+
+
+class TestMiniMaxClientInit(unittest.TestCase):
+    """Test MiniMaxClient initialization."""
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    @patch("PE.minimax_client.OpenAI")
+    def test_init_with_env_key(self, mock_openai_cls):
+        """Client should initialize with API key from environment."""
+        from PE.minimax_client import MiniMaxClient
+        client = MiniMaxClient()
+        self.assertEqual(client.api_key, "test-key-123")
+        self.assertEqual(client.model, "MiniMax-M2.7")
+        mock_openai_cls.assert_called_once_with(
+            api_key="test-key-123",
+            base_url="https://api.minimax.io/v1",
+        )
+
+    @patch("PE.minimax_client.OpenAI")
+    def test_init_with_explicit_key(self, mock_openai_cls):
+        """Client should initialize with explicitly provided API key."""
+        from PE.minimax_client import MiniMaxClient
+        client = MiniMaxClient(api_key="explicit-key")
+        self.assertEqual(client.api_key, "explicit-key")
+
+    @patch("PE.minimax_client.OpenAI")
+    def test_init_with_custom_model(self, mock_openai_cls):
+        """Client should accept a custom model name."""
+        from PE.minimax_client import MiniMaxClient
+        client = MiniMaxClient(api_key="key", model="MiniMax-M2.5")
+        self.assertEqual(client.model, "MiniMax-M2.5")
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("PE.minimax_client.OpenAI")
+    def test_init_no_key_raises(self, mock_openai_cls):
+        """Client should raise ValueError if no API key is available."""
+        from PE.minimax_client import MiniMaxClient
+        # Remove any existing env var
+        os.environ.pop("MINIMAX_API_KEY", None)
+        with self.assertRaises(ValueError) as ctx:
+            MiniMaxClient()
+        self.assertIn("MINIMAX_API_KEY", str(ctx.exception))
+
+    def test_init_no_openai_package(self):
+        """Client should raise ImportError if openai package is missing."""
+        import PE.minimax_client as mod
+        original = mod.OpenAI
+        mod.OpenAI = None
+        try:
+            with self.assertRaises(ImportError) as ctx:
+                mod.MiniMaxClient(api_key="key")
+            self.assertIn("openai", str(ctx.exception))
+        finally:
+            mod.OpenAI = original
+
+
+class TestMiniMaxClientRecaption(unittest.TestCase):
+    """Test MiniMaxClient.run_single_recaption method."""
+
+    def _make_mock_response(self, content):
+        """Create a mock OpenAI response object."""
+        mock_message = MagicMock()
+        mock_message.content = content
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        return mock_response
+
+    @patch("PE.minimax_client.OpenAI")
+    def test_recaption_basic(self, mock_openai_cls):
+        """Basic recaption should return enhanced prompt and empty reason."""
+        from PE.minimax_client import MiniMaxClient
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = self._make_mock_response(
+            "A cinematic wide-angle shot of a brown and white border collie."
+        )
+
+        client = MiniMaxClient(api_key="test-key")
+        content, reason = client.run_single_recaption(
+            "You are a prompt engineer.", "A dog running."
+        )
+
+        self.assertIn("border collie", content)
+        self.assertEqual(reason, "")
+        mock_client.chat.completions.create.assert_called_once()
+
+    @patch("PE.minimax_client.OpenAI")
+    def test_recaption_strips_think_tags(self, mock_openai_cls):
+        """Think tags in response should be stripped."""
+        from PE.minimax_client import MiniMaxClient
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = self._make_mock_response(
+            "<think>Let me enhance this...</think>Enhanced prompt here."
+        )
+
+        client = MiniMaxClient(api_key="test-key")
+        content, reason = client.run_single_recaption("system", "user prompt")
+
+        self.assertEqual(content, "Enhanced prompt here.")
+        self.assertNotIn("<think>", content)
+
+    @patch("PE.minimax_client.OpenAI")
+    def test_recaption_empty_content(self, mock_openai_cls):
+        """Empty content from API should return empty string."""
+        from PE.minimax_client import MiniMaxClient
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = self._make_mock_response(None)
+
+        client = MiniMaxClient(api_key="test-key")
+        content, reason = client.run_single_recaption("system", "user prompt")
+
+        self.assertEqual(content, "")
+
+    @patch("PE.minimax_client.OpenAI")
+    def test_recaption_api_params(self, mock_openai_cls):
+        """API call should use correct parameters."""
+        from PE.minimax_client import MiniMaxClient
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = self._make_mock_response("result")
+
+        client = MiniMaxClient(api_key="test-key", model="MiniMax-M2.5")
+        client.run_single_recaption("sys prompt", "user prompt")
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        self.assertEqual(call_kwargs["model"], "MiniMax-M2.5")
+        self.assertEqual(len(call_kwargs["messages"]), 2)
+        self.assertEqual(call_kwargs["messages"][0]["role"], "system")
+        self.assertEqual(call_kwargs["messages"][0]["content"], "sys prompt")
+        self.assertEqual(call_kwargs["messages"][1]["role"], "user")
+        self.assertEqual(call_kwargs["messages"][1]["content"], "user prompt")
+        self.assertGreater(call_kwargs["temperature"], 0.0)
+        self.assertLessEqual(call_kwargs["temperature"], 1.0)
+        self.assertFalse(call_kwargs["stream"])
+
+    @patch("PE.minimax_client.OpenAI")
+    def test_recaption_retry_on_error(self, mock_openai_cls):
+        """Client should retry on transient API errors."""
+        from PE.minimax_client import MiniMaxClient
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+
+        # First call raises, second succeeds
+        mock_client.chat.completions.create.side_effect = [
+            Exception("Connection timeout"),
+            self._make_mock_response("Enhanced prompt."),
+        ]
+
+        client = MiniMaxClient(api_key="test-key")
+        with patch("PE.minimax_client.time.sleep"):  # Skip actual sleep
+            content, reason = client.run_single_recaption("system", "prompt")
+
+        self.assertEqual(content, "Enhanced prompt.")
+        self.assertEqual(mock_client.chat.completions.create.call_count, 2)
+
+    @patch("PE.minimax_client.OpenAI")
+    def test_recaption_long_prompt(self, mock_openai_cls):
+        """Client should handle long prompts without truncation."""
+        from PE.minimax_client import MiniMaxClient
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        long_response = "Enhanced: " + "word " * 500
+        mock_client.chat.completions.create.return_value = self._make_mock_response(
+            long_response
+        )
+
+        client = MiniMaxClient(api_key="test-key")
+        content, reason = client.run_single_recaption("system", "A " * 1000)
+
+        self.assertEqual(content, long_response.strip())
+
+    @patch("PE.minimax_client.OpenAI")
+    def test_base_url(self, mock_openai_cls):
+        """Client should use MiniMax API base URL."""
+        from PE.minimax_client import MiniMaxClient
+        MiniMaxClient(api_key="test-key")
+        call_kwargs = mock_openai_cls.call_args[1]
+        self.assertEqual(call_kwargs["base_url"], "https://api.minimax.io/v1")
+
+    @patch("PE.minimax_client.OpenAI")
+    def test_default_model(self, mock_openai_cls):
+        """Default model should be MiniMax-M2.7."""
+        from PE.minimax_client import MiniMaxClient
+        client = MiniMaxClient(api_key="test-key")
+        self.assertEqual(client.model, "MiniMax-M2.7")
+
+    @patch("PE.minimax_client.OpenAI")
+    def test_temperature_constraint(self, mock_openai_cls):
+        """Temperature must be in (0.0, 1.0] for MiniMax API."""
+        from PE.minimax_client import MiniMaxClient
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = self._make_mock_response("ok")
+
+        client = MiniMaxClient(api_key="test-key")
+        client.run_single_recaption("system", "prompt")
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        temp = call_kwargs["temperature"]
+        self.assertGreater(temp, 0.0)
+        self.assertLessEqual(temp, 1.0)
+
+
+class TestRunImageGenArgs(unittest.TestCase):
+    """Test argument parsing for run_image_gen.py with LLM provider support."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Mock hunyuan_image_3 module so run_image_gen.py can be imported."""
+        cls._mock_module = MagicMock()
+        sys.modules["hunyuan_image_3"] = cls._mock_module
+
+    @classmethod
+    def tearDownClass(cls):
+        """Remove mock module."""
+        sys.modules.pop("hunyuan_image_3", None)
+
+    def _parse(self, extra_args):
+        """Parse args with required arguments plus extras."""
+        base = ["--prompt", "test", "--model-id", "/tmp/fake"]
+        with patch("sys.argv", ["run_image_gen.py"] + base + extra_args):
+            # Re-import to get fresh parse_args
+            import importlib
+            import run_image_gen
+            importlib.reload(run_image_gen)
+            return run_image_gen.parse_args()
+
+    def test_default_llm_provider(self):
+        """Default LLM provider should be deepseek."""
+        args = self._parse([])
+        self.assertEqual(args.llm_provider, "deepseek")
+
+    def test_minimax_provider(self):
+        """--llm-provider minimax should be accepted."""
+        args = self._parse(["--llm-provider", "minimax"])
+        self.assertEqual(args.llm_provider, "minimax")
+
+    def test_default_sys_prompt_type(self):
+        """Default system prompt type should be universal."""
+        args = self._parse([])
+        self.assertEqual(args.sys_prompt_type, "universal")
+
+    def test_text_rendering_prompt_type(self):
+        """--sys-prompt-type text_rendering should be accepted."""
+        args = self._parse(["--sys-prompt-type", "text_rendering"])
+        self.assertEqual(args.sys_prompt_type, "text_rendering")
+
+    def test_invalid_provider_rejected(self):
+        """Invalid provider name should be rejected by argparse."""
+        with self.assertRaises(SystemExit):
+            self._parse(["--llm-provider", "invalid_provider"])
+
+    def test_rewrite_default_off(self):
+        """Rewrite should be disabled by default."""
+        args = self._parse([])
+        self.assertEqual(args.rewrite, 0)
+
+    def test_rewrite_enabled(self):
+        """--rewrite 1 should enable rewriting."""
+        args = self._parse(["--rewrite", "1"])
+        self.assertEqual(args.rewrite, 1)
+
+
+class TestProviderDispatch(unittest.TestCase):
+    """Test the LLM provider dispatch logic in run_image_gen.main()."""
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"})
+    @patch("PE.minimax_client.OpenAI")
+    def test_minimax_provider_dispatch(self, mock_openai_cls):
+        """When llm_provider is minimax, MiniMaxClient should be used."""
+        from PE.minimax_client import MiniMaxClient
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+
+        mock_message = MagicMock()
+        mock_message.content = "Enhanced prompt."
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_client.chat.completions.create.return_value = mock_response
+
+        client = MiniMaxClient(api_key="test-key")
+        content, reason = client.run_single_recaption(
+            "You are a prompt engineer.", "A dog running."
+        )
+        self.assertEqual(content, "Enhanced prompt.")
+        self.assertEqual(reason, "")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_minimax_provider_no_key_raises(self):
+        """MiniMax provider without API key should raise ValueError."""
+        os.environ.pop("MINIMAX_API_KEY", None)
+        from PE.minimax_client import MiniMaxClient
+        # Mock OpenAI to avoid import error
+        with patch("PE.minimax_client.OpenAI"):
+            with self.assertRaises(ValueError) as ctx:
+                MiniMaxClient()
+            self.assertIn("MINIMAX_API_KEY", str(ctx.exception))
+
+
+class TestSystemPromptCompatibility(unittest.TestCase):
+    """Test that system prompts work correctly with MiniMax provider."""
+
+    def test_system_prompts_are_strings(self):
+        """System prompts should be non-empty strings."""
+        from PE.system_prompt import system_prompt_universal, system_prompt_text_rendering
+        self.assertIsInstance(system_prompt_universal, str)
+        self.assertIsInstance(system_prompt_text_rendering, str)
+        self.assertGreater(len(system_prompt_universal), 100)
+        self.assertGreater(len(system_prompt_text_rendering), 100)
+
+    def test_system_prompts_provider_agnostic(self):
+        """System prompts should not reference any specific provider."""
+        from PE.system_prompt import system_prompt_universal, system_prompt_text_rendering
+        for prompt in [system_prompt_universal, system_prompt_text_rendering]:
+            # System prompts describe image generation tasks, not LLM providers
+            self.assertNotIn("DeepSeek", prompt)
+            self.assertNotIn("deepseek", prompt)
+
+
+# ---------------------------------------------------------------------------
+# Integration Tests
+# ---------------------------------------------------------------------------
+
+class TestMiniMaxIntegration(unittest.TestCase):
+    """Integration tests for MiniMax prompt enhancement (requires API key)."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Check if MiniMax API key is available."""
+        cls.api_key = os.getenv("MINIMAX_API_KEY")
+        if not cls.api_key:
+            raise unittest.SkipTest("MINIMAX_API_KEY not set, skipping integration tests")
+
+    def test_real_recaption_universal(self):
+        """Test real prompt enhancement with universal system prompt."""
+        from PE.minimax_client import MiniMaxClient
+        from PE.system_prompt import system_prompt_universal
+
+        client = MiniMaxClient(api_key=self.api_key)
+        content, reason = client.run_single_recaption(
+            system_prompt_universal,
+            "A cat sitting on a windowsill"
+        )
+
+        self.assertIsInstance(content, str)
+        self.assertGreater(len(content), 10)
+        # Enhanced prompt should be longer/more detailed than input
+        self.assertGreater(len(content), len("A cat sitting on a windowsill"))
+
+    def test_real_recaption_text_rendering(self):
+        """Test real prompt enhancement with text rendering system prompt."""
+        from PE.minimax_client import MiniMaxClient
+        from PE.system_prompt import system_prompt_text_rendering
+
+        client = MiniMaxClient(api_key=self.api_key)
+        content, reason = client.run_single_recaption(
+            system_prompt_text_rendering,
+            'A poster with the text "Hello World"'
+        )
+
+        self.assertIsInstance(content, str)
+        self.assertGreater(len(content), 10)
+
+    def test_real_recaption_m25(self):
+        """Test prompt enhancement with MiniMax-M2.5 model."""
+        from PE.minimax_client import MiniMaxClient
+        from PE.system_prompt import system_prompt_universal
+
+        client = MiniMaxClient(api_key=self.api_key, model="MiniMax-M2.5")
+        content, reason = client.run_single_recaption(
+            system_prompt_universal,
+            "A sunset over mountains"
+        )
+
+        self.assertIsInstance(content, str)
+        self.assertGreater(len(content), 10)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add **MiniMax Cloud API** as an alternative LLM provider for prompt enhancement (PE) in HunyuanImage-3.0, alongside the existing DeepSeek/Tencent Cloud integration
- Introduce `--llm-provider` CLI flag (`deepseek`/`minimax`) and `--sys-prompt-type` flag (`universal`/`text_rendering`) for flexible prompt rewriting configuration
- MiniMax uses an OpenAI-compatible API at `https://api.minimax.io/v1` with models like MiniMax-M2.7 (1M context window) — users only need `pip install openai` and a `MINIMAX_API_KEY`

## Changes

| File | Description |
|------|-------------|
| `PE/minimax_client.py` | New `MiniMaxClient` class with OpenAI-compat API, temperature clamping (0,1], think-tag stripping, retry logic |
| `run_image_gen.py` | Multi-provider dispatch via `--llm-provider` flag, new `--sys-prompt-type` arg (fixes missing arg reference) |
| `README.md` | MiniMax installation step, usage example, CLI arguments table |
| `tests/test_minimax_provider.py` | 31 unit tests + 3 integration tests |

## Motivation

The current PE module only supports DeepSeek via Tencent Cloud's LKEAP SDK, which requires Tencent Cloud credentials. Adding MiniMax as an alternative:
- Provides a simpler setup path (standard OpenAI SDK + API key)
- Gives users choice of LLM backend for prompt enhancement
- MiniMax-M2.7 offers a 1M token context window suitable for complex prompt engineering

## Test plan

- [x] 31 unit tests covering: think-tag stripping, client init, recaption, arg parsing, provider dispatch, system prompt compatibility
- [x] 3 integration tests with real MiniMax API (universal prompt, text rendering, M2.5 model)
- [x] All 34 tests passing
- [ ] Manual test: `python3 run_image_gen.py --prompt 'test' --rewrite 1 --llm-provider minimax` (requires GPU for full image generation)

## Usage

```bash
# With MiniMax PE
export MINIMAX_API_KEY="your_key"
python3 run_image_gen.py \
    --model-id ./HunyuanImage-3 \
    --prompt "A brown and white dog running on grass" \
    --rewrite 1 \
    --llm-provider minimax
```