### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,4 +564,4 @@ We extend our heartfelt gratitude to the following open-source projects and comm
 [![GitHub forks](https://img.shields.io/github/forks/Tencent-Hunyuan/HunyuanImage-3.0?style=social)](https://github.com/Tencent-Hunyuan/HunyuanImage-3.0)
 
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Tencent-Hunyuan/HunyuanImage-3.0&type=Date)](https://www.star-history.com/#Tencent-Hunyuan/HunyuanImage-3.0&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Tencent-Hunyuan/HunyuanImage-3.0&type=Date)](https://star-history.dera.page/#Tencent-Hunyuan/HunyuanImage-3.0&Date)

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -564,4 +564,4 @@ HunyuanImage-3.0-Instruct 展示了在智能图像生成和编辑方面的强大
 [![GitHub stars](https://img.shields.io/github/stars/Tencent-Hunyuan/HunyuanImage-3.0?style=social)](https://github.com/Tencent-Hunyuan/HunyuanImage-3.0)
 [![GitHub forks](https://img.shields.io/github/forks/Tencent-Hunyuan/HunyuanImage-3.0?style=social)](https://github.com/Tencent-Hunyuan/HunyuanImage-3.0)
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Tencent-Hunyuan/HunyuanImage-3.0&type=Date)](https://www.star-history.com/#Tencent-Hunyuan/HunyuanImage-3.0&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Tencent-Hunyuan/HunyuanImage-3.0&type=Date)](https://star-history.dera.page/#Tencent-Hunyuan/HunyuanImage-3.0&Date)


### PR DESCRIPTION
The star history chart in the READMEs is currently broken because the old data source is no longer available due to GitHub stargazer API restrictions. This change points the chart to a working alternative that needs no API token, restoring the star history display in both the English and Chinese READMEs.